### PR TITLE
Replacing usages of apache commons-lang with commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <guava.version>15.0</guava.version>
     <commons.fileupload.version>1.2.2</commons.fileupload.version>
     <commons-io.version>1.3.2</commons-io.version>
-    <velocity.version>1.7</velocity.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
     <hibernate-validator.version>5.0.2.Final</hibernate-validator.version>
     <commons-cli.version>1.2</commons-cli.version>

--- a/src/main/java/org/alien4cloud/plugin/kubernetes/AbstractKubernetesModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/AbstractKubernetesModifier.java
@@ -27,7 +27,7 @@ import org.alien4cloud.tosca.normative.primitives.SizeUnit;
 import org.alien4cloud.tosca.normative.types.SizeType;
 import org.alien4cloud.tosca.normative.types.ToscaTypes;
 import org.alien4cloud.tosca.utils.TopologyNavigationUtil;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import jakarta.annotation.Resource;
 


### PR DESCRIPTION
* parent project has migrated to commons-lang3 and old version is no longer available at the runtime;
* removed Apache Velocity version property from `pom.xml` because it is not used in this project;